### PR TITLE
Param to restrict broadcast responses to specific network interfaces in multi card setups.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -548,7 +548,7 @@ declare namespace DHCP {
         emit(event: string | symbol, ...args: any[]): boolean;
 
         bind(address?: string): void;
-        send(packet: Packet): void;
+        send(packet: Packet, address?: string): void;
     }
 
     export interface ServerOptions {

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -103,12 +103,12 @@ export class Socket extends EventEmitter {
         this.socket.bind(this.listenPort, address);
     }
 
-    send(packet: Packet) {
+    send(packet: Packet, address: string = BROADCAST) {
         this.emit("send", {
             target: this,
             packet
         });
         let buf = packet.toBuffer();
-        this.socket.send(buf, 0, buf.length, this.sendPort, BROADCAST);
+        this.socket.send(buf, 0, buf.length, this.sendPort, address);
     }
 }


### PR DESCRIPTION
On Linux (and I think OSX as well), to only respond on specific network interfaces or on multicard setups, the packet must be sent to each of the interfaces' broadcast address (i.e. 192.168.0.255 for 192.168.0.0/24); .setBroadcast(true) is already set in socket.js, but it is still needed to specify the broadcast address of the target network card, if a route for 255.255.255.255 to redirect all local broadcast traffic is not set.

Also, on Linux (and I think OSX as well) in a multi card setup, by default, packets sent to 255.255.255.255 only go through the first physical card.

Thank you :)
