### PR TITLE
Changes to support layer 3 DHCP through DHCP relay

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -485,6 +485,7 @@ declare namespace DHCP {
         sname: string;
         file: string;
         options: PacketOptions;
+        reinfo?: AddressInfo;
         /**
          * Возвращает тип DHCP пакета
          *
@@ -548,7 +549,7 @@ declare namespace DHCP {
         emit(event: string | symbol, ...args: any[]): boolean;
 
         bind(address?: string): void;
-        send(packet: Packet, address?: string): void;
+        send(packet: Packet, address?: string, sendPort?: number): void;
     }
 
     export interface ServerOptions {

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -1,3 +1,5 @@
+import { AddressInfo } from "dgram";
+
 import { DEFAULT_MAC, DEFAULT_IP } from "./const";
 import { BOOTMessageType, DHCPOptions, DHCPMessageType } from "./enum";
 import { IpConverter, MacConverter } from "./converters";
@@ -66,6 +68,7 @@ export class Packet {
     sname: string = "";
     file: string = "";
     options: PacketOptions = [];
+    reinfo?: AddressInfo = undefined;
 
     /**
      * Returns DHCPMessageType of DHCP packet

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -59,6 +59,7 @@ export class Socket extends EventEmitter {
         let buf = new Buffer(msg, "binary");
 
         let packet = Packet.fromBuffer(buf);
+        packet.reinfo = reinfo;
 
         if ((packet.op === BOOTMessageType.request || packet.op === BOOTMessageType.reply) &&
             packet.options.some(option => option.type === DHCPOptions.DhcpMessageType)) {
@@ -103,12 +104,20 @@ export class Socket extends EventEmitter {
         this.socket.bind(this.listenPort, address);
     }
 
-    send(packet: Packet, address: string = BROADCAST) {
+    send(packet: Packet, address: string = BROADCAST, sendPort?: number) {
         this.emit("send", {
             target: this,
-            packet
+            packet, 
+            address, 
+            sendPort
         });
         let buf = packet.toBuffer();
-        this.socket.send(buf, 0, buf.length, this.sendPort, address);
+
+        if(typeof sendPort !== "number")
+        {
+            sendPort = this.sendPort;
+        }
+
+        this.socket.send(buf, 0, buf.length, sendPort, address);
     }
 }


### PR DESCRIPTION
When replying to a relay, it is necessary to be able to override the sendPort with 67, not the default 68.

This scenario:

```JavaScript
if(event.packet.giaddr && event.packet.giaddr !== "0.0.0.0")
{
	console.log(`Sending reply to giaddr (DHCP relay) ${event.packet.giaddr}`);
	event.target.send(ackPacket, event.packet.giaddr, 67);
}
else if(event.packet.reinfo.address === "0.0.0.0")
{
	console.log(`Sending reply to broadcast addresses ${this._arrBroadcastAddresses.join(", ")}`);
	for(let strBroadcastAddress of this._arrBroadcastAddresses)
	{
		event.target.send(ackPacket, strBroadcastAddress);
	}
}
else
{
	console.log(`Sending reply to UDP source address ${event.packet.reinfo.address}`);
	event.target.send(ackPacket, event.packet.reinfo.address);
}
```