### PR TITLE
Increase package buffer size to 576 bytes to match the maximum DHCP package size from RFC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhcp-mon",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "NodeJS implementation of DHCP socket connection",
   "main": "out/index.js",
   "module": "out/index.mjs",

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -110,7 +110,7 @@ export class Packet {
      * @memberOf Packet
      */
     public toBuffer(): Buffer {
-        const buffer = Buffer.alloc(512);
+        const buffer = Buffer.alloc(576);
         buffer.fill(0);
 
         buffer[0] = this.op;


### PR DESCRIPTION
[RFC-2131](https://www.ietf.org/rfc/rfc2131.txt) specifies:
"... This requirement implies that a DHCP client must be prepared to receive a message of up to 576 octets, the minimum IP
datagram size an IP host must be prepared to accept."

We've ran into an issue where we had a packet larger than 512 bytes which was truncated and thus dropped by a switch since it was now invalid.